### PR TITLE
Fix IS NULL/TRUE/FALSE AND/OR parsing and add dollar-quoted strings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,29 +8,244 @@ permissions:
   id-token: write
   attestations: write
 
+env:
+  TREE_SITTER_ABI_VERSION: 15
+
 jobs:
   release:
     uses: tree-sitter/workflows/.github/workflows/release.yml@main
     with:
       generate: true
 
-  npm:
-    uses: tree-sitter/workflows/.github/workflows/package-npm.yml@main
-    with:
-      generate: true
-    secrets:
-      NODE_AUTH_TOKEN: ${{ secrets.NODE_AUTH_TOKEN }}
+  # ── crates.io (trusted publishing via OIDC) ──────────────────────────────────
 
   crates:
-    uses: tree-sitter/workflows/.github/workflows/package-crates.yml@main
-    with:
-      generate: true
-    secrets:
-      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    name: Publish Rust package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: crates
+      url: https://crates.io/crates/tree-sitter-postgres
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Set up tree-sitter CLI
+        uses: tree-sitter/setup-action/cli@v2
+      - name: Regenerate parser
+        run: |
+          while read -r grammar_dir; do
+            pushd "$grammar_dir"
+            tree-sitter generate
+            popd > /dev/null
+          done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
+      - name: Publish to crates.io
+        run: cargo publish
+
+  # ── PyPI (trusted publishing via OIDC) ────────────────────────────────────────
+
+  build_sdist:
+    name: Build source dist
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+      - name: Set up tree-sitter CLI
+        uses: tree-sitter/setup-action/cli@v2
+      - name: Regenerate parser
+        shell: bash
+        run: |
+          while read -r grammar_dir; do
+            pushd "$grammar_dir"
+            tree-sitter generate
+            popd > /dev/null
+          done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
+      - name: Install build tools
+        run: pip install --upgrade pip build setuptools wheel
+      - name: Build sources
+        run: python -mbuild -n -s
+      - name: Upload sources
+        uses: actions/upload-artifact@v7
+        with:
+          name: dist-sources
+          path: dist/*.tar.gz
+          retention-days: 2
+
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-2025
+          - windows-11-arm
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-15
+          - macos-15-intel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up tree-sitter CLI
+        uses: tree-sitter/setup-action/cli@v2
+      - name: Regenerate parser
+        shell: bash
+        run: |
+          while read -r grammar_dir; do
+            grammar_dir="${grammar_dir%$'\r'}"
+            pushd "$grammar_dir"
+            tree-sitter generate
+            popd > /dev/null
+          done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.4
+        with:
+          output-dir: dist
+        env:
+          CIBW_ARCHS: native
+      - name: Upload wheel artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          path: dist/*.whl
+          name: dist-wheels-${{ matrix.os }}
+          retention-days: 2
 
   pypi:
-    uses: tree-sitter/workflows/.github/workflows/package-pypi.yml@main
-    with:
-      generate: true
-    secrets:
-      PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+    name: Publish Python package
+    needs: [build_sdist, build_wheels]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/project/tree-sitter-postgres/
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          pattern: dist-*
+          merge-multiple: true
+      - name: Check build artifacts
+        run: ls -l dist
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  # ── npm (trusted publishing via OIDC provenance) ──────────────────────────────
+
+  build_wasm:
+    name: Build Wasm binaries
+    runs-on: ubuntu-24.04
+    continue-on-error: true
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up NodeJS
+        uses: actions/setup-node@v6
+        with:
+          cache: npm
+          node-version: "22"
+      - name: Install dependencies
+        run: npm i --omit peer --omit optional
+      - name: Regenerate parser
+        run: |
+          while read -r grammar_dir; do
+            pushd "$grammar_dir"
+            npm x -- tree-sitter generate
+            popd > /dev/null
+          done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
+      - name: Build Wasm binaries
+        run: |-
+          while read -r grammar_dir; do
+            npm x -- tree-sitter build --wasm "$grammar_dir"
+          done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
+      - name: Upload binaries
+        uses: actions/upload-artifact@v7
+        with:
+          path: "*.wasm"
+          name: prebuilds-wasm
+          retention-days: 2
+
+  build_node:
+    name: Build NodeJS binaries on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - windows-2025
+          - windows-11-arm
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+          - macos-15
+          - macos-15-intel
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up NodeJS
+        uses: actions/setup-node@v6
+        with:
+          cache: npm
+          node-version: "22"
+      - name: Install dependencies
+        run: npm i --omit peer --omit optional
+      - name: Regenerate parser
+        shell: bash
+        run: |
+          while read -r grammar_dir; do
+            grammar_dir="${grammar_dir%$'\r'}"
+            pushd "$grammar_dir"
+            npm x -- tree-sitter generate
+            popd > /dev/null
+          done < <(jq -r '.grammars[].path // "."' tree-sitter.json)
+      - name: Build binary
+        run: npm x -- prebuildify -t 20.19.5
+      - name: Upload binaries
+        uses: actions/upload-artifact@v7
+        with:
+          path: prebuilds/**
+          name: prebuilds-${{ matrix.os }}
+          retention-days: 2
+
+  npm:
+    name: Publish NodeJS package
+    needs: [build_wasm, build_node]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/tree-sitter-postgres
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Set up NodeJS
+        uses: actions/setup-node@v6
+        with:
+          cache: npm
+          node-version: "22"
+          registry-url: https://registry.npmjs.org/
+      - name: Download binaries
+        uses: actions/download-artifact@v8
+        with:
+          path: prebuilds
+          pattern: prebuilds-*
+          merge-multiple: true
+      - name: Check binaries
+        run: tree prebuilds
+      - name: Move Wasm binaries to root
+        continue-on-error: true
+        run: mv -v prebuilds/*.wasm .
+      - name: Publish to npm
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,7 +196,7 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-postgres"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "cc",
  "tree-sitter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-postgres"
 description = "Postgres grammar for tree-sitter"
-version = "0.1.0"
+version = "1.0.0"
 license = "BSD-3-Clause"
 readme = "README.md"
 keywords = ["incremental", "parsing", "tree-sitter", "postgres"]

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 # tree-sitter-postgres justfile
 
-version := "0.1.0"
+version := "1.0.0"
 language_name := "tree-sitter-postgres"
 ts := "./node_modules/.bin/tree-sitter"
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "node-gyp-build": "^4.8.1"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.21.1"
+    "tree-sitter": ">=0.25.0"
   },
   "peerDependenciesMeta": {
     "tree-sitter": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tree-sitter-postgres",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "PostgreSQL grammar for tree-sitter, generated from Postgres source",
   "main": "bindings/node",
   "types": "bindings/node",

--- a/postgres/grammar.js
+++ b/postgres/grammar.js
@@ -1076,8 +1076,8 @@ module.exports = grammar({
       ),
     event_trigger_when_item: $ => prec.left(8, prec.dynamic(8, seq($.ColId, $.kw_in, '(', $.event_trigger_value_list, ')'))),
     event_trigger_value_list: $ => choice(
-        $.string_literal,
-        seq($.event_trigger_value_list, ',', $.string_literal)
+        choice($.string_literal, $.dollar_quoted_string),
+        seq($.event_trigger_value_list, ',', choice($.string_literal, $.dollar_quoted_string))
       ),
     AlterEventTrigStmt: $ => seq($.kw_alter, $.kw_event, $.kw_trigger, $.name, $.enable_trigger),
     enable_trigger: $ => choice(
@@ -2646,11 +2646,7 @@ module.exports = grammar({
         prec.left(15, prec.dynamic(15, seq($.a_expr_prec, '^', $.a_expr_prec))),
         prec.left(7, prec.dynamic(7, seq($.a_expr_prec, '<', $.a_expr_prec))),
         prec.left(7, prec.dynamic(7, seq($.a_expr_prec, '>', $.a_expr_prec))),
-        prec.left(7, prec.dynamic(7, seq($.a_expr_prec, '=', $.a_expr_prec))),
-        prec.left(4, prec.dynamic(4, seq($.a_expr_prec, $.kw_and, $.a_expr_prec))),
-        prec.left(3, prec.dynamic(3, seq($.a_expr_prec, $.kw_or, $.a_expr_prec))),
-        prec.right(5, prec.dynamic(5, seq($.kw_not, $.a_expr_prec))),
-        prec.right(5, prec.dynamic(5, seq($.kw_not, $.a_expr_prec)))
+        prec.left(7, prec.dynamic(7, seq($.a_expr_prec, '=', $.a_expr_prec)))
       ),
     a_expr: $ => choice(
         alias($.a_expr_prec, $.a_expr),
@@ -2660,6 +2656,10 @@ module.exports = grammar({
         prec.left(7, prec.dynamic(7, seq($.a_expr, '<>', $.a_expr))),
         prec.left(12, prec.dynamic(12, seq($.a_expr, $.qual_Op, $.a_expr))),
         prec.left(12, prec.dynamic(12, seq($.qual_Op, $.a_expr))),
+        prec.left(4, prec.dynamic(4, seq($.a_expr, $.kw_and, $.a_expr))),
+        prec.left(3, prec.dynamic(3, seq($.a_expr, $.kw_or, $.a_expr))),
+        prec.right(5, prec.dynamic(5, seq($.kw_not, $.a_expr))),
+        prec.right(5, prec.dynamic(5, seq($.kw_not, $.a_expr))),
         prec.left(8, prec.dynamic(8, seq($.a_expr, $.kw_like, $.a_expr))),
         prec.left(8, prec.dynamic(8, seq($.a_expr, $.kw_like, $.a_expr, $.kw_escape, $.a_expr))),
         prec.left(8, prec.dynamic(8, seq($.a_expr, $.kw_not, $.kw_like, $.a_expr))),
@@ -3175,7 +3175,7 @@ module.exports = grammar({
         $.kw_null
       ),
     Iconst: $ => $.integer_literal,
-    Sconst: $ => $.string_literal,
+    Sconst: $ => choice($.string_literal, $.dollar_quoted_string),
     SignedIconst: $ => choice(
         $.Iconst,
         prec.left(13, prec.dynamic(13, seq('+', $.Iconst))),

--- a/postgres/src/grammar.json
+++ b/postgres/src/grammar.json
@@ -1,30 +1,48 @@
 {
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/grammar.schema.json",
   "name": "postgres",
   "word": "identifier",
   "rules": {
     "source_file": {
-      "type": "REPEAT",
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "CHOICE",
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
             "members": [
               {
-                "type": "SYMBOL",
-                "name": "toplevel_stmt"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "toplevel_stmt"
+                  },
+                  {
+                    "type": "BLANK"
+                  }
+                ]
               },
               {
-                "type": "BLANK"
+                "type": "STRING",
+                "value": ";"
               }
             ]
-          },
-          {
-            "type": "STRING",
-            "value": ";"
           }
-        ]
-      }
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "toplevel_stmt"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        }
+      ]
     },
     "toplevel_stmt": {
       "type": "CHOICE",
@@ -15232,8 +15250,17 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "string_literal"
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "string_literal"
+            },
+            {
+              "type": "SYMBOL",
+              "name": "dollar_quoted_string"
+            }
+          ]
         },
         {
           "type": "SEQ",
@@ -15247,8 +15274,17 @@
               "value": ","
             },
             {
-              "type": "SYMBOL",
-              "name": "string_literal"
+              "type": "CHOICE",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "string_literal"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "dollar_quoted_string"
+                }
+              ]
             }
           ]
         }
@@ -41804,98 +41840,6 @@
               ]
             }
           }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 4,
-          "content": {
-            "type": "PREC_DYNAMIC",
-            "value": 4,
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "a_expr_prec"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "kw_and"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "a_expr_prec"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "type": "PREC_LEFT",
-          "value": 3,
-          "content": {
-            "type": "PREC_DYNAMIC",
-            "value": 3,
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "a_expr_prec"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "kw_or"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "a_expr_prec"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "type": "PREC_RIGHT",
-          "value": 5,
-          "content": {
-            "type": "PREC_DYNAMIC",
-            "value": 5,
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "kw_not"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "a_expr_prec"
-                }
-              ]
-            }
-          }
-        },
-        {
-          "type": "PREC_RIGHT",
-          "value": 5,
-          "content": {
-            "type": "PREC_DYNAMIC",
-            "value": 5,
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "kw_not"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "a_expr_prec"
-                }
-              ]
-            }
-          }
         }
       ]
     },
@@ -42056,6 +42000,98 @@
                 {
                   "type": "SYMBOL",
                   "name": "qual_Op"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "a_expr"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 4,
+          "content": {
+            "type": "PREC_DYNAMIC",
+            "value": 4,
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "a_expr"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "kw_and"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "a_expr"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 3,
+          "content": {
+            "type": "PREC_DYNAMIC",
+            "value": 3,
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "a_expr"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "kw_or"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "a_expr"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 5,
+          "content": {
+            "type": "PREC_DYNAMIC",
+            "value": 5,
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "kw_not"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "a_expr"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "PREC_RIGHT",
+          "value": 5,
+          "content": {
+            "type": "PREC_DYNAMIC",
+            "value": 5,
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "kw_not"
                 },
                 {
                   "type": "SYMBOL",
@@ -47607,8 +47643,16 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "operator"
+          "type": "PREC_LEFT",
+          "value": 12,
+          "content": {
+            "type": "PREC_DYNAMIC",
+            "value": 12,
+            "content": {
+              "type": "SYMBOL",
+              "name": "operator"
+            }
+          }
         },
         {
           "type": "SYMBOL",
@@ -47769,8 +47813,16 @@
       "type": "CHOICE",
       "members": [
         {
-          "type": "SYMBOL",
-          "name": "operator"
+          "type": "PREC_LEFT",
+          "value": 12,
+          "content": {
+            "type": "PREC_DYNAMIC",
+            "value": 12,
+            "content": {
+              "type": "SYMBOL",
+              "name": "operator"
+            }
+          }
         },
         {
           "type": "PREC_LEFT",
@@ -50295,8 +50347,17 @@
       "name": "integer_literal"
     },
     "Sconst": {
-      "type": "SYMBOL",
-      "name": "string_literal"
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "string_literal"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "dollar_quoted_string"
+        }
+      ]
     },
     "SignedIconst": {
       "type": "CHOICE",
@@ -60232,7 +60293,7 @@
           },
           {
             "type": "PATTERN",
-            "value": "\\.[0-9](_?[0-9])*([eE][+-]?[0-9](_?[0-9])*)? "
+            "value": "\\.[0-9](_?[0-9])*([eE][+-]?[0-9](_?[0-9])*)?"
           },
           {
             "type": "PATTERN",
@@ -60246,13 +60307,6 @@
       "content": {
         "type": "PATTERN",
         "value": "'([^']|'')*'"
-      }
-    },
-    "escape_string_literal": {
-      "type": "TOKEN",
-      "content": {
-        "type": "PATTERN",
-        "value": "[eE]'([^'\\\\]|\\\\.)*'"
       }
     },
     "dollar_quoted_string": {
@@ -60274,13 +60328,6 @@
       "content": {
         "type": "PATTERN",
         "value": "[xX]'[0-9a-fA-F]*'"
-      }
-    },
-    "national_string_literal": {
-      "type": "TOKEN",
-      "content": {
-        "type": "PATTERN",
-        "value": "[nN]'([^']|'')*'"
       }
     },
     "operator": {
@@ -60358,5 +60405,6 @@
   "precedences": [],
   "externals": [],
   "inline": [],
-  "supertypes": []
+  "supertypes": [],
+  "reserved": {}
 }

--- a/postgres/src/node-types.json
+++ b/postgres/src/node-types.json
@@ -6763,57 +6763,6 @@
     }
   },
   {
-    "type": "PLpgSQL_Expr",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": true,
-      "required": true,
-      "types": [
-        {
-          "type": "from_clause",
-          "named": true
-        },
-        {
-          "type": "group_clause",
-          "named": true
-        },
-        {
-          "type": "having_clause",
-          "named": true
-        },
-        {
-          "type": "opt_distinct_clause",
-          "named": true
-        },
-        {
-          "type": "opt_for_locking_clause",
-          "named": true
-        },
-        {
-          "type": "opt_select_limit",
-          "named": true
-        },
-        {
-          "type": "opt_sort_clause",
-          "named": true
-        },
-        {
-          "type": "opt_target_list",
-          "named": true
-        },
-        {
-          "type": "where_clause",
-          "named": true
-        },
-        {
-          "type": "window_clause",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "PartitionBoundSpec",
     "named": true,
     "fields": {},
@@ -7921,6 +7870,10 @@
       "multiple": false,
       "required": true,
       "types": [
+        {
+          "type": "dollar_quoted_string",
+          "named": true
+        },
         {
           "type": "string_literal",
           "named": true
@@ -9465,10 +9418,6 @@
           "named": true
         },
         {
-          "type": "kw_and",
-          "named": true
-        },
-        {
           "type": "kw_at",
           "named": true
         },
@@ -9478,14 +9427,6 @@
         },
         {
           "type": "kw_local",
-          "named": true
-        },
-        {
-          "type": "kw_not",
-          "named": true
-        },
-        {
-          "type": "kw_or",
           "named": true
         }
       ]
@@ -14334,6 +14275,10 @@
       "required": true,
       "types": [
         {
+          "type": "dollar_quoted_string",
+          "named": true
+        },
+        {
           "type": "event_trigger_value_list",
           "named": true
         },
@@ -18909,25 +18854,6 @@
     }
   },
   {
-    "type": "opt_distinct_clause",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "distinct_clause",
-          "named": true
-        },
-        {
-          "type": "opt_all_clause",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
     "type": "opt_drop_behavior",
     "named": true,
     "fields": {},
@@ -20664,30 +20590,6 @@
       "types": [
         {
           "type": "kw_path",
-          "named": true
-        }
-      ]
-    }
-  },
-  {
-    "type": "plassign_equals",
-    "named": true,
-    "fields": {}
-  },
-  {
-    "type": "plassign_target",
-    "named": true,
-    "fields": {},
-    "children": {
-      "multiple": false,
-      "required": true,
-      "types": [
-        {
-          "type": "ColId",
-          "named": true
-        },
-        {
-          "type": "param",
           "named": true
         }
       ]
@@ -22538,6 +22440,7 @@
   {
     "type": "source_file",
     "named": true,
+    "root": true,
     "fields": {},
     "children": {
       "multiple": true,
@@ -26048,6 +25951,11 @@
   },
   {
     "type": "comment",
+    "named": true,
+    "extra": true
+  },
+  {
+    "type": "dollar_quoted_string",
     "named": true
   },
   {

--- a/postgres/src/parser.c
+++ b/postgres/src/parser.c
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c1c137a2403292d43a969d556afad3dc6271472074f8dd9d0784c3a1dc2a7427
-size 89942953
+oid sha256:77ec3b62dc9cbb9ae8dac66e1c234d59b80c5a865878fcdecbaeb49eb5d1d387
+size 92447278

--- a/postgres/src/tree_sitter/alloc.h
+++ b/postgres/src/tree_sitter/alloc.h
@@ -12,10 +12,10 @@ extern "C" {
 // Allow clients to override allocation functions
 #ifdef TREE_SITTER_REUSE_ALLOCATOR
 
-extern void *(*ts_current_malloc)(size_t);
-extern void *(*ts_current_calloc)(size_t, size_t);
-extern void *(*ts_current_realloc)(void *, size_t);
-extern void (*ts_current_free)(void *);
+extern void *(*ts_current_malloc)(size_t size);
+extern void *(*ts_current_calloc)(size_t count, size_t size);
+extern void *(*ts_current_realloc)(void *ptr, size_t size);
+extern void (*ts_current_free)(void *ptr);
 
 #ifndef ts_malloc
 #define ts_malloc  ts_current_malloc

--- a/postgres/src/tree_sitter/array.h
+++ b/postgres/src/tree_sitter/array.h
@@ -14,6 +14,7 @@ extern "C" {
 #include <string.h>
 
 #ifdef _MSC_VER
+#pragma warning(push)
 #pragma warning(disable : 4101)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
@@ -51,67 +52,96 @@ extern "C" {
 
 /// Reserve `new_capacity` elements of space in the array. If `new_capacity` is
 /// less than the array's current capacity, this function has no effect.
-#define array_reserve(self, new_capacity) \
-  _array__reserve((Array *)(self), array_elem_size(self), new_capacity)
+#define array_reserve(self, new_capacity)        \
+  ((self)->contents = _array__reserve(           \
+    (void *)(self)->contents, &(self)->capacity, \
+    array_elem_size(self), new_capacity)         \
+  )
 
 /// Free any memory allocated for this array. Note that this does not free any
 /// memory allocated for the array's contents.
-#define array_delete(self) _array__delete((Array *)(self))
+#define array_delete(self)                           \
+  do {                                               \
+    if ((self)->contents) ts_free((self)->contents); \
+    (self)->contents = NULL;                         \
+    (self)->size = 0;                                \
+    (self)->capacity = 0;                            \
+  } while (0)
 
 /// Push a new `element` onto the end of the array.
-#define array_push(self, element)                            \
-  (_array__grow((Array *)(self), 1, array_elem_size(self)), \
-   (self)->contents[(self)->size++] = (element))
+#define array_push(self, element)                                 \
+  do {                                                            \
+    (self)->contents = _array__grow(                              \
+      (void *)(self)->contents, (self)->size, &(self)->capacity,  \
+      1, array_elem_size(self)                                    \
+    );                                                            \
+   (self)->contents[(self)->size++] = (element);                  \
+  } while(0)
 
 /// Increase the array's size by `count` elements.
 /// New elements are zero-initialized.
-#define array_grow_by(self, count) \
-  do { \
-    if ((count) == 0) break; \
-    _array__grow((Array *)(self), count, array_elem_size(self)); \
+#define array_grow_by(self, count)                                               \
+  do {                                                                           \
+    if ((count) == 0) break;                                                     \
+    (self)->contents = _array__grow(                                             \
+      (self)->contents, (self)->size, &(self)->capacity,                         \
+      count, array_elem_size(self)                                               \
+    );                                                                           \
     memset((self)->contents + (self)->size, 0, (count) * array_elem_size(self)); \
-    (self)->size += (count); \
+    (self)->size += (count);                                                     \
   } while (0)
 
 /// Append all elements from one array to the end of another.
-#define array_push_all(self, other)                                       \
+#define array_push_all(self, other) \
   array_extend((self), (other)->size, (other)->contents)
 
 /// Append `count` elements to the end of the array, reading their values from the
 /// `contents` pointer.
-#define array_extend(self, count, contents)                    \
-  _array__splice(                                               \
-    (Array *)(self), array_elem_size(self), (self)->size, \
-    0, count,  contents                                        \
+#define array_extend(self, count, other_contents)                 \
+  (self)->contents = _array__splice(                              \
+    (void*)(self)->contents, &(self)->size, &(self)->capacity,    \
+    array_elem_size(self), (self)->size, 0, count, other_contents \
   )
 
 /// Remove `old_count` elements from the array starting at the given `index`. At
 /// the same index, insert `new_count` new elements, reading their values from the
 /// `new_contents` pointer.
-#define array_splice(self, _index, old_count, new_count, new_contents)  \
-  _array__splice(                                                       \
-    (Array *)(self), array_elem_size(self), _index,                \
-    old_count, new_count, new_contents                                 \
+#define array_splice(self, _index, old_count, new_count, new_contents) \
+  (self)->contents = _array__splice(                                   \
+    (void *)(self)->contents, &(self)->size, &(self)->capacity,        \
+    array_elem_size(self), _index, old_count, new_count, new_contents  \
   )
 
 /// Insert one `element` into the array at the given `index`.
-#define array_insert(self, _index, element) \
-  _array__splice((Array *)(self), array_elem_size(self), _index, 0, 1, &(element))
+#define array_insert(self, _index, element)                     \
+  (self)->contents = _array__splice(                            \
+    (void *)(self)->contents, &(self)->size, &(self)->capacity, \
+    array_elem_size(self), _index, 0, 1, &(element)             \
+  )
 
 /// Remove one element from the array at the given `index`.
 #define array_erase(self, _index) \
-  _array__erase((Array *)(self), array_elem_size(self), _index)
+  _array__erase((void *)(self)->contents, &(self)->size, array_elem_size(self), _index)
 
 /// Pop the last element off the array, returning the element by value.
 #define array_pop(self) ((self)->contents[--(self)->size])
 
 /// Assign the contents of one array to another, reallocating if necessary.
-#define array_assign(self, other) \
-  _array__assign((Array *)(self), (const Array *)(other), array_elem_size(self))
+#define array_assign(self, other)                                   \
+  (self)->contents = _array__assign(                                \
+    (void *)(self)->contents, &(self)->size, &(self)->capacity,     \
+    (const void *)(other)->contents, (other)->size, array_elem_size(self) \
+  )
 
 /// Swap one array with another
-#define array_swap(self, other) \
-  _array__swap((Array *)(self), (Array *)(other))
+#define array_swap(self, other)                                     \
+  do {                                                              \
+    void *_array_swap_tmp = (void *)(self)->contents;               \
+    (self)->contents = (other)->contents;                           \
+    (other)->contents = _array_swap_tmp;                            \
+    _array__swap(&(self)->size, &(self)->capacity,                  \
+                 &(other)->size, &(other)->capacity);               \
+  } while (0)
 
 /// Get the size of the array contents
 #define array_elem_size(self) (sizeof *(self)->contents)
@@ -156,82 +186,90 @@ extern "C" {
 
 // Private
 
-typedef Array(void) Array;
-
-/// This is not what you're looking for, see `array_delete`.
-static inline void _array__delete(Array *self) {
-  if (self->contents) {
-    ts_free(self->contents);
-    self->contents = NULL;
-    self->size = 0;
-    self->capacity = 0;
-  }
-}
+// Pointers to individual `Array` fields (rather than the entire `Array` itself)
+// are passed to the various `_array__*` functions below to address strict aliasing
+// violations that arises when the _entire_ `Array` struct is passed as `Array(void)*`.
+//
+// The `Array` type itself was not altered as a solution in order to avoid breakage
+// with existing consumers (in particular, parsers with external scanners).
 
 /// This is not what you're looking for, see `array_erase`.
-static inline void _array__erase(Array *self, size_t element_size,
-                                uint32_t index) {
-  assert(index < self->size);
-  char *contents = (char *)self->contents;
+static inline void _array__erase(void* self_contents, uint32_t *size,
+                                size_t element_size, uint32_t index) {
+  assert(index < *size);
+  char *contents = (char *)self_contents;
   memmove(contents + index * element_size, contents + (index + 1) * element_size,
-          (self->size - index - 1) * element_size);
-  self->size--;
+          (*size - index - 1) * element_size);
+  (*size)--;
 }
 
 /// This is not what you're looking for, see `array_reserve`.
-static inline void _array__reserve(Array *self, size_t element_size, uint32_t new_capacity) {
-  if (new_capacity > self->capacity) {
-    if (self->contents) {
-      self->contents = ts_realloc(self->contents, new_capacity * element_size);
+static inline void *_array__reserve(void *contents, uint32_t *capacity,
+                                  size_t element_size, uint32_t new_capacity) {
+  void *new_contents = contents;
+  if (new_capacity > *capacity) {
+    if (contents) {
+      new_contents = ts_realloc(contents, new_capacity * element_size);
     } else {
-      self->contents = ts_malloc(new_capacity * element_size);
+      new_contents = ts_malloc(new_capacity * element_size);
     }
-    self->capacity = new_capacity;
+    *capacity = new_capacity;
   }
+  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_assign`.
-static inline void _array__assign(Array *self, const Array *other, size_t element_size) {
-  _array__reserve(self, element_size, other->size);
-  self->size = other->size;
-  memcpy(self->contents, other->contents, self->size * element_size);
+static inline void *_array__assign(void* self_contents, uint32_t *self_size, uint32_t *self_capacity,
+                                 const void *other_contents, uint32_t other_size, size_t element_size) {
+  void *new_contents = _array__reserve(self_contents, self_capacity, element_size, other_size);
+  *self_size = other_size;
+  memcpy(new_contents, other_contents, *self_size * element_size);
+  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_swap`.
-static inline void _array__swap(Array *self, Array *other) {
-  Array swap = *other;
-  *other = *self;
-  *self = swap;
+static inline void _array__swap(uint32_t *self_size, uint32_t *self_capacity,
+                               uint32_t *other_size, uint32_t *other_capacity) {
+  uint32_t tmp_size = *self_size;
+  uint32_t tmp_capacity = *self_capacity;
+  *self_size = *other_size;
+  *self_capacity = *other_capacity;
+  *other_size = tmp_size;
+  *other_capacity = tmp_capacity;
 }
 
 /// This is not what you're looking for, see `array_push` or `array_grow_by`.
-static inline void _array__grow(Array *self, uint32_t count, size_t element_size) {
-  uint32_t new_size = self->size + count;
-  if (new_size > self->capacity) {
-    uint32_t new_capacity = self->capacity * 2;
+static inline void *_array__grow(void *contents, uint32_t size, uint32_t *capacity,
+                               uint32_t count, size_t element_size) {
+  void *new_contents = contents;
+  uint32_t new_size = size + count;
+  if (new_size > *capacity) {
+    uint32_t new_capacity = *capacity * 2;
     if (new_capacity < 8) new_capacity = 8;
     if (new_capacity < new_size) new_capacity = new_size;
-    _array__reserve(self, element_size, new_capacity);
+    new_contents = _array__reserve(contents, capacity, element_size, new_capacity);
   }
+  return new_contents;
 }
 
 /// This is not what you're looking for, see `array_splice`.
-static inline void _array__splice(Array *self, size_t element_size,
+static inline void *_array__splice(void *self_contents, uint32_t *size, uint32_t *capacity,
+                                 size_t element_size,
                                  uint32_t index, uint32_t old_count,
                                  uint32_t new_count, const void *elements) {
-  uint32_t new_size = self->size + new_count - old_count;
+  uint32_t new_size = *size + new_count - old_count;
   uint32_t old_end = index + old_count;
   uint32_t new_end = index + new_count;
-  assert(old_end <= self->size);
+  assert(old_end <= *size);
 
-  _array__reserve(self, element_size, new_size);
+  void *new_contents = _array__reserve(self_contents, capacity, element_size, new_size);
 
-  char *contents = (char *)self->contents;
-  if (self->size > old_end) {
+  char *contents = (char *)new_contents;
+  if (*size > old_end) {
     memmove(
       contents + new_end * element_size,
       contents + old_end * element_size,
-      (self->size - old_end) * element_size
+      (*size - old_end) * element_size
     );
   }
   if (new_count > 0) {
@@ -249,7 +287,9 @@ static inline void _array__splice(Array *self, size_t element_size,
       );
     }
   }
-  self->size += new_count - old_count;
+  *size += new_count - old_count;
+
+  return new_contents;
 }
 
 /// A binary search routine, based on Rust's `std::slice::binary_search_by`.
@@ -278,7 +318,7 @@ static inline void _array__splice(Array *self, size_t element_size,
 #define _compare_int(a, b) ((int)*(a) - (int)(b))
 
 #ifdef _MSC_VER
-#pragma warning(default : 4101)
+#pragma warning(pop)
 #elif defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
 #endif

--- a/postgres/src/tree_sitter/parser.h
+++ b/postgres/src/tree_sitter/parser.h
@@ -18,6 +18,11 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +31,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -79,6 +85,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -93,7 +105,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -109,13 +121,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -129,15 +141,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -145,7 +165,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 

--- a/postgres/test/corpus/expressions.txt
+++ b/postgres/test/corpus/expressions.txt
@@ -81,20 +81,22 @@ SELECT a AND b OR c;
                 (target_el
                   (a_expr
                     (a_expr
-                      (a_expr_prec
-                        (a_expr_prec
-                          (c_expr
-                            (columnref
-                              (ColId
-                                (identifier)))))
-                        (kw_and)
-                        (a_expr_prec
+                      (a_expr
+                        (a_expr
                           (c_expr
                             (columnref
                               (ColId
                                 (identifier))))))
-                      (kw_or)
-                      (a_expr_prec
+                      (kw_and)
+                      (a_expr
+                        (a_expr
+                          (c_expr
+                            (columnref
+                              (ColId
+                                (identifier)))))))
+                    (kw_or)
+                    (a_expr
+                      (a_expr
                         (c_expr
                           (columnref
                             (ColId

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ readme = "README.md"
 Homepage = "https://github.com/gmr/tree-sitter-postgres"
 
 [project.optional-dependencies]
-core = ["tree-sitter~=0.22"]
+core = ["tree-sitter>=0.25"]
 
 [tool.cibuildwheel]
 build = "cp39-*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-postgres"
 description = "Postgres grammar for tree-sitter"
-version = "0.1.0"
+version = "1.0.0"
 keywords = ["incremental", "parsing", "tree-sitter", "postgres"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/script/codegen.js
+++ b/script/codegen.js
@@ -50,8 +50,8 @@ const BASE_TOKEN_MAP = {
   IDENT:   '$.identifier',
   UIDENT:  '$.identifier',   // reduced to IDENT in PG lexer
   FCONST:  '$.float_literal',
-  SCONST:  '$.string_literal',
-  USCONST: '$.string_literal',  // reduced to SCONST in PG lexer
+  SCONST:  'choice($.string_literal, $.dollar_quoted_string)',
+  USCONST: 'choice($.string_literal, $.dollar_quoted_string)',  // reduced to SCONST in PG lexer
   BCONST:  '$.bit_string_literal',
   XCONST:  '$.hex_string_literal',
   ICONST:  '$.integer_literal',
@@ -325,27 +325,33 @@ function generateExprRule(name, rule, terminals, kwTokenMap, optionalRules, prec
     const precInfo = determinePrecedence(alt, precMap, terminals);
 
     // A "prec-resolvable" alternative must be a simple binary/unary pattern
-    // with a LITERAL operator (single-char like +, -, *, etc.) or specific
-    // boolean keywords (AND, OR, NOT). Complex keyword operators (IS, LIKE,
-    // ILIKE, etc.) have multiple alternatives starting the same way and
-    // create multi-way conflicts that need GLR.
+    // with a LITERAL operator (single-char like +, -, *, etc.). These go into
+    // the self-referential _prec rule for static precedence resolution.
+    //
+    // AND, OR, and NOT are kept in the main (complex) rule so they reference
+    // $.a_expr instead of $.a_expr_prec. This allows IS/ISNULL/NOTNULL results
+    // (which are a_expr, not a_expr_prec) to participate as operands of boolean
+    // operators. Without this, `a IS NULL AND b = 1` cannot parse because the
+    // IS result can't be consumed by a_expr_prec's AND rule.
+    //
+    // Complex keyword operators (IS, LIKE, ILIKE, etc.) have multiple
+    // alternatives starting the same way and create multi-way conflicts
+    // that need GLR.
     let isCleanOp = false;
     if (precInfo && syntaxTokens.length >= 2 && syntaxTokens.length <= 3) {
       // Binary: self OP self (where OP is a literal or operator token)
       if (syntaxTokens.length === 3
           && syntaxTokens[0].type === 'SYMBOL' && syntaxTokens[0].value === name
           && syntaxTokens[2].type === 'SYMBOL' && syntaxTokens[2].value === name
-          && (syntaxTokens[1].type === 'LITERAL'
-              || (syntaxTokens[1].type === 'SYMBOL'
-                  && (syntaxTokens[1].value === 'AND' || syntaxTokens[1].value === 'OR')))) {
+          && syntaxTokens[1].type === 'LITERAL') {
         isCleanOp = true;
       }
       // Binary postfix: self OP arg (like TYPECAST Typename, COLLATE any_name)
       // These have unique operator tokens that don't create multi-way conflicts.
       // The operator must have declared precedence and not be a complex keyword
-      // that starts multiple alternatives (like IS, IN, LIKE, etc.)
+      // that starts multiple alternatives (like IS, IN, LIKE, AND, OR, etc.)
       const complexKw = new Set(['IS', 'ISNULL', 'NOTNULL', 'IN_P', 'LIKE', 'ILIKE',
-        'SIMILAR', 'BETWEEN', 'NOT', 'NOT_LA']);
+        'SIMILAR', 'BETWEEN', 'NOT', 'NOT_LA', 'AND', 'OR']);
       if (syntaxTokens.length === 3
           && syntaxTokens[0].type === 'SYMBOL' && syntaxTokens[0].value === name
           && syntaxTokens[1].type === 'SYMBOL' && !complexKw.has(syntaxTokens[1].value)
@@ -357,13 +363,6 @@ function generateExprRule(name, rule, terminals, kwTokenMap, optionalRules, prec
       if (syntaxTokens.length === 2
           && syntaxTokens[0].type === 'LITERAL'
           && syntaxTokens[1].type === 'SYMBOL' && syntaxTokens[1].value === name) {
-        isCleanOp = true;
-      }
-      // Boolean unary: NOT self
-      if (syntaxTokens.length === 2
-          && syntaxTokens[1].type === 'SYMBOL' && syntaxTokens[1].value === name
-          && syntaxTokens[0].type === 'SYMBOL'
-          && (syntaxTokens[0].value === 'NOT' || syntaxTokens[0].value === 'NOT_LA')) {
         isCleanOp = true;
       }
     }

--- a/tree-sitter.json
+++ b/tree-sitter.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "version": "0.1.0",
+    "version": "1.0.0",
     "license": "BSD-3-Clause",
     "description": "PostgreSQL grammar for tree-sitter, generated from PostgreSQL source",
     "authors": [


### PR DESCRIPTION
## Summary

- Move AND, OR, and NOT from `a_expr_prec` to `a_expr` in the codegen so IS/ISNULL/NOTNULL results can participate as operands of boolean operators. Fixes `a IS NULL AND b = 1` and similar patterns producing ERROR nodes.
- Add dollar-quoted string support (`$$...$$` and `$tag$...$tag$`) to SCONST token mapping so `CREATE FUNCTION ... AS $$body$$` parses correctly.
- Update Boolean operators corpus test to match new tree structure.

Fixes all issues documented in GRAMMAR-ISSUES.md.

## Test plan

- [x] All 35 corpus tests pass
- [x] `SELECT 1 WHERE a IS NOT NULL AND b = 1;` — no errors
- [x] `SELECT 1 WHERE a = 1 AND b IS NULL AND c = 1;` — no errors
- [x] `SELECT 1 WHERE a IS TRUE AND b = 1;` — no errors
- [x] `SELECT 1 WHERE a IS NOT FALSE AND b = 1;` — no errors
- [x] `SELECT 1 WHERE (a IS NULL OR b > 1) AND c = 3;` — no errors
- [x] `CREATE FUNCTION ... AS $$ body $$;` — dollar-quoted body parsed as string
- [x] `CREATE FUNCTION ... AS $body$ body $body$;` — tagged dollar-quote works
- [x] Previously-passing cases still parse correctly

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PostgreSQL grammar now accepts dollar-quoted string literals alongside standard strings in more places.
  * Expression parsing updated to change how boolean operators and comparison precedences are associated, improving parse structure.

* **Chores**
  * Released version 1.0.0 across package manifests and build metadata.
  * Publication workflow reworked to explicit build/publish jobs and updated publish flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->