### PR TITLE
Add plpgsql language injection for function bodies

### DIFF
--- a/postgres/queries/injections.scm
+++ b/postgres/queries/injections.scm
@@ -1,10 +1,509 @@
 ; injections.scm — tree-sitter-postgres language injection queries
 ;
-; PL/pgSQL function bodies inside CREATE FUNCTION / CREATE PROCEDURE
-; are delegated to the plpgsql grammar for detailed parsing.
+; Dollar-quoted function bodies in CREATE FUNCTION / CREATE PROCEDURE
+; are injected as plpgsql or postgres depending on the LANGUAGE clause.
+;
+; The createfunc_opt_list is left-recursive, so the LANGUAGE and AS items
+; may be at varying nesting depths depending on how many options appear.
+; Patterns cover depths 1-6 (2-7 createfunc_opt_items) in both orderings,
+; which handles all practical CREATE FUNCTION statements.
 
-((func_as
-  (Sconst
-    (dollar_quoted_string) @injection.content))
-  (#set! injection.language "plpgsql")
-  (#set! injection.include-children))
+; ============================================================
+; PL/pgSQL injection
+; ============================================================
+
+; 2 options: LANGUAGE deeper, AS rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_item
+          (kw_language)
+          (NonReservedWord_or_Sconst
+            (NonReservedWord
+              (identifier) @_lang))))
+      (createfunc_opt_item
+        (func_as
+          (Sconst
+            (dollar_quoted_string) @injection.content))))))
+ (#eq? @_lang "plpgsql")
+ (#set! injection.language "plpgsql")
+ (#set! injection.include-children))
+
+; 2 options: AS deeper, LANGUAGE rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_item
+          (func_as
+            (Sconst
+              (dollar_quoted_string) @injection.content))))
+      (createfunc_opt_item
+        (kw_language)
+        (NonReservedWord_or_Sconst
+          (NonReservedWord
+            (identifier) @_lang))))))
+ (#eq? @_lang "plpgsql")
+ (#set! injection.language "plpgsql")
+ (#set! injection.include-children))
+
+; 3 options: LANGUAGE deeper, AS rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_item
+            (kw_language)
+            (NonReservedWord_or_Sconst
+              (NonReservedWord
+                (identifier) @_lang)))))
+      (createfunc_opt_item
+        (func_as
+          (Sconst
+            (dollar_quoted_string) @injection.content))))))
+ (#eq? @_lang "plpgsql")
+ (#set! injection.language "plpgsql")
+ (#set! injection.include-children))
+
+; 3 options: AS deeper, LANGUAGE rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_item
+            (func_as
+              (Sconst
+                (dollar_quoted_string) @injection.content)))))
+      (createfunc_opt_item
+        (kw_language)
+        (NonReservedWord_or_Sconst
+          (NonReservedWord
+            (identifier) @_lang))))))
+ (#eq? @_lang "plpgsql")
+ (#set! injection.language "plpgsql")
+ (#set! injection.include-children))
+
+; 4 options: LANGUAGE deeper, AS rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_item
+              (kw_language)
+              (NonReservedWord_or_Sconst
+                (NonReservedWord
+                  (identifier) @_lang))))))
+      (createfunc_opt_item
+        (func_as
+          (Sconst
+            (dollar_quoted_string) @injection.content))))))
+ (#eq? @_lang "plpgsql")
+ (#set! injection.language "plpgsql")
+ (#set! injection.include-children))
+
+; 4 options: AS deeper, LANGUAGE rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_item
+              (func_as
+                (Sconst
+                  (dollar_quoted_string) @injection.content))))))
+      (createfunc_opt_item
+        (kw_language)
+        (NonReservedWord_or_Sconst
+          (NonReservedWord
+            (identifier) @_lang))))))
+ (#eq? @_lang "plpgsql")
+ (#set! injection.language "plpgsql")
+ (#set! injection.include-children))
+
+; 5 options: LANGUAGE deeper, AS rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_list
+              (createfunc_opt_item
+                (kw_language)
+                (NonReservedWord_or_Sconst
+                  (NonReservedWord
+                    (identifier) @_lang)))))))
+      (createfunc_opt_item
+        (func_as
+          (Sconst
+            (dollar_quoted_string) @injection.content))))))
+ (#eq? @_lang "plpgsql")
+ (#set! injection.language "plpgsql")
+ (#set! injection.include-children))
+
+; 5 options: AS deeper, LANGUAGE rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_list
+              (createfunc_opt_item
+                (func_as
+                  (Sconst
+                    (dollar_quoted_string) @injection.content)))))))
+      (createfunc_opt_item
+        (kw_language)
+        (NonReservedWord_or_Sconst
+          (NonReservedWord
+            (identifier) @_lang))))))
+ (#eq? @_lang "plpgsql")
+ (#set! injection.language "plpgsql")
+ (#set! injection.include-children))
+
+; 6 options: LANGUAGE deeper, AS rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_list
+              (createfunc_opt_list
+                (createfunc_opt_item
+                  (kw_language)
+                  (NonReservedWord_or_Sconst
+                    (NonReservedWord
+                      (identifier) @_lang))))))))
+      (createfunc_opt_item
+        (func_as
+          (Sconst
+            (dollar_quoted_string) @injection.content))))))
+ (#eq? @_lang "plpgsql")
+ (#set! injection.language "plpgsql")
+ (#set! injection.include-children))
+
+; 6 options: AS deeper, LANGUAGE rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_list
+              (createfunc_opt_list
+                (createfunc_opt_item
+                  (func_as
+                    (Sconst
+                      (dollar_quoted_string) @injection.content))))))))
+      (createfunc_opt_item
+        (kw_language)
+        (NonReservedWord_or_Sconst
+          (NonReservedWord
+            (identifier) @_lang))))))
+ (#eq? @_lang "plpgsql")
+ (#set! injection.language "plpgsql")
+ (#set! injection.include-children))
+
+; 7 options: LANGUAGE deeper, AS rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_list
+              (createfunc_opt_list
+                (createfunc_opt_list
+                  (createfunc_opt_item
+                    (kw_language)
+                    (NonReservedWord_or_Sconst
+                      (NonReservedWord
+                        (identifier) @_lang)))))))))
+      (createfunc_opt_item
+        (func_as
+          (Sconst
+            (dollar_quoted_string) @injection.content))))))
+ (#eq? @_lang "plpgsql")
+ (#set! injection.language "plpgsql")
+ (#set! injection.include-children))
+
+; 7 options: AS deeper, LANGUAGE rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_list
+              (createfunc_opt_list
+                (createfunc_opt_list
+                  (createfunc_opt_item
+                    (func_as
+                      (Sconst
+                        (dollar_quoted_string) @injection.content)))))))))
+      (createfunc_opt_item
+        (kw_language)
+        (NonReservedWord_or_Sconst
+          (NonReservedWord
+            (identifier) @_lang))))))
+ (#eq? @_lang "plpgsql")
+ (#set! injection.language "plpgsql")
+ (#set! injection.include-children))
+
+; ============================================================
+; SQL injection (postgres self-injection)
+; ============================================================
+
+; 2 options: LANGUAGE deeper, AS rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_item
+          (kw_language)
+          (NonReservedWord_or_Sconst
+            (NonReservedWord
+              (unreserved_keyword
+                (kw_sql))))))
+      (createfunc_opt_item
+        (func_as
+          (Sconst
+            (dollar_quoted_string) @injection.content))))))
+ (#set! injection.language "sql")
+ (#set! injection.include-children))
+
+; 2 options: AS deeper, LANGUAGE rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_item
+          (func_as
+            (Sconst
+              (dollar_quoted_string) @injection.content))))
+      (createfunc_opt_item
+        (kw_language)
+        (NonReservedWord_or_Sconst
+          (NonReservedWord
+            (unreserved_keyword
+              (kw_sql))))))))
+ (#set! injection.language "sql")
+ (#set! injection.include-children))
+
+; 3 options: LANGUAGE deeper, AS rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_item
+            (kw_language)
+            (NonReservedWord_or_Sconst
+              (NonReservedWord
+                (unreserved_keyword
+                  (kw_sql)))))))
+      (createfunc_opt_item
+        (func_as
+          (Sconst
+            (dollar_quoted_string) @injection.content))))))
+ (#set! injection.language "sql")
+ (#set! injection.include-children))
+
+; 3 options: AS deeper, LANGUAGE rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_item
+            (func_as
+              (Sconst
+                (dollar_quoted_string) @injection.content)))))
+      (createfunc_opt_item
+        (kw_language)
+        (NonReservedWord_or_Sconst
+          (NonReservedWord
+            (unreserved_keyword
+              (kw_sql))))))))
+ (#set! injection.language "sql")
+ (#set! injection.include-children))
+
+; 4 options: LANGUAGE deeper, AS rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_item
+              (kw_language)
+              (NonReservedWord_or_Sconst
+                (NonReservedWord
+                  (unreserved_keyword
+                    (kw_sql))))))))
+      (createfunc_opt_item
+        (func_as
+          (Sconst
+            (dollar_quoted_string) @injection.content))))))
+ (#set! injection.language "sql")
+ (#set! injection.include-children))
+
+; 4 options: AS deeper, LANGUAGE rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_item
+              (func_as
+                (Sconst
+                  (dollar_quoted_string) @injection.content))))))
+      (createfunc_opt_item
+        (kw_language)
+        (NonReservedWord_or_Sconst
+          (NonReservedWord
+            (unreserved_keyword
+              (kw_sql))))))))
+ (#set! injection.language "sql")
+ (#set! injection.include-children))
+
+; 5 options: LANGUAGE deeper, AS rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_list
+              (createfunc_opt_item
+                (kw_language)
+                (NonReservedWord_or_Sconst
+                  (NonReservedWord
+                    (unreserved_keyword
+                      (kw_sql)))))))))
+      (createfunc_opt_item
+        (func_as
+          (Sconst
+            (dollar_quoted_string) @injection.content))))))
+ (#set! injection.language "sql")
+ (#set! injection.include-children))
+
+; 5 options: AS deeper, LANGUAGE rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_list
+              (createfunc_opt_item
+                (func_as
+                  (Sconst
+                    (dollar_quoted_string) @injection.content)))))))
+      (createfunc_opt_item
+        (kw_language)
+        (NonReservedWord_or_Sconst
+          (NonReservedWord
+            (unreserved_keyword
+              (kw_sql))))))))
+ (#set! injection.language "sql")
+ (#set! injection.include-children))
+
+; 6 options: LANGUAGE deeper, AS rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_list
+              (createfunc_opt_list
+                (createfunc_opt_item
+                  (kw_language)
+                  (NonReservedWord_or_Sconst
+                    (NonReservedWord
+                      (unreserved_keyword
+                        (kw_sql))))))))))
+      (createfunc_opt_item
+        (func_as
+          (Sconst
+            (dollar_quoted_string) @injection.content))))))
+ (#set! injection.language "sql")
+ (#set! injection.include-children))
+
+; 6 options: AS deeper, LANGUAGE rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_list
+              (createfunc_opt_list
+                (createfunc_opt_item
+                  (func_as
+                    (Sconst
+                      (dollar_quoted_string) @injection.content))))))))
+      (createfunc_opt_item
+        (kw_language)
+        (NonReservedWord_or_Sconst
+          (NonReservedWord
+            (unreserved_keyword
+              (kw_sql))))))))
+ (#set! injection.language "sql")
+ (#set! injection.include-children))
+
+; 7 options: LANGUAGE deeper, AS rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_list
+              (createfunc_opt_list
+                (createfunc_opt_list
+                  (createfunc_opt_item
+                    (kw_language)
+                    (NonReservedWord_or_Sconst
+                      (NonReservedWord
+                        (unreserved_keyword
+                          (kw_sql)))))))))))
+      (createfunc_opt_item
+        (func_as
+          (Sconst
+            (dollar_quoted_string) @injection.content))))))
+ (#set! injection.language "sql")
+ (#set! injection.include-children))
+
+; 7 options: AS deeper, LANGUAGE rightmost
+((CreateFunctionStmt
+  (opt_createfunc_opt_list
+    (createfunc_opt_list
+      (createfunc_opt_list
+        (createfunc_opt_list
+          (createfunc_opt_list
+            (createfunc_opt_list
+              (createfunc_opt_list
+                (createfunc_opt_list
+                  (createfunc_opt_item
+                    (func_as
+                      (Sconst
+                        (dollar_quoted_string) @injection.content)))))))))
+      (createfunc_opt_item
+        (kw_language)
+        (NonReservedWord_or_Sconst
+          (NonReservedWord
+            (unreserved_keyword
+              (kw_sql))))))))
+ (#set! injection.language "sql")
+ (#set! injection.include-children))

--- a/postgres/queries/injections.scm
+++ b/postgres/queries/injections.scm
@@ -1,0 +1,10 @@
+; injections.scm — tree-sitter-postgres language injection queries
+;
+; PL/pgSQL function bodies inside CREATE FUNCTION / CREATE PROCEDURE
+; are delegated to the plpgsql grammar for detailed parsing.
+
+((func_as
+  (Sconst
+    (dollar_quoted_string) @injection.content))
+  (#set! injection.language "plpgsql")
+  (#set! injection.include-children))


### PR DESCRIPTION
## Summary

- Adds `postgres/queries/injections.scm` to inject the plpgsql grammar into dollar-quoted function bodies (`AS $$...$$`) in `CREATE FUNCTION` / `CREATE PROCEDURE` statements
- Enables proper PL/pgSQL syntax highlighting and analysis inside SQL files for editors that support tree-sitter language injection (Neovim, Helix, Zed, Emacs)

## Test plan

- [ ] Open a SQL file containing `CREATE FUNCTION ... AS $$ BEGIN ... END $$` in an editor with tree-sitter injection support
- [ ] Verify the function body is highlighted as PL/pgSQL rather than an opaque string
- [ ] Verify regular dollar-quoted strings outside `func_as` are not affected

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Better PostgreSQL language support: improved syntax highlighting and parsing for dollar-quoted function/procedure bodies.
  * Automatic detection of embedded language: correctly treats dollar-quoted bodies as PL/pgSQL or SQL based on the function's LANGUAGE setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->