### PR TITLE
fix(injections): match PL/pgSQL language case-insensitively

### DIFF
--- a/postgres/queries/injections.scm
+++ b/postgres/queries/injections.scm
@@ -26,7 +26,7 @@
         (func_as
           (Sconst
             (dollar_quoted_string) @injection.content))))))
- (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
+ (?i)^plpgsql$
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -44,7 +44,7 @@
         (NonReservedWord_or_Sconst
           (NonReservedWord
             (identifier) @_lang))))))
- (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
+ (?i)^plpgsql$
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -63,7 +63,7 @@
         (func_as
           (Sconst
             (dollar_quoted_string) @injection.content))))))
- (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
+(?i)^plpgsql$
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -82,7 +82,7 @@
         (NonReservedWord_or_Sconst
           (NonReservedWord
             (identifier) @_lang))))))
- (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
+ (?i)^plpgsql$
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -102,7 +102,7 @@
         (func_as
           (Sconst
             (dollar_quoted_string) @injection.content))))))
- (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
+ (?i)^plpgsql$
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -122,7 +122,7 @@
         (NonReservedWord_or_Sconst
           (NonReservedWord
             (identifier) @_lang))))))
- (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
+ (?i)^plpgsql$
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -143,7 +143,7 @@
         (func_as
           (Sconst
             (dollar_quoted_string) @injection.content))))))
- (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
+ (?i)^plpgsql$
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -164,7 +164,7 @@
         (NonReservedWord_or_Sconst
           (NonReservedWord
             (identifier) @_lang))))))
- (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
+ (?i)^plpgsql$
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -186,7 +186,7 @@
         (func_as
           (Sconst
             (dollar_quoted_string) @injection.content))))))
- (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
+ (?i)^plpgsql$
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -208,7 +208,7 @@
         (NonReservedWord_or_Sconst
           (NonReservedWord
             (identifier) @_lang))))))
- (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
+ (?i)^plpgsql$
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -231,7 +231,7 @@
         (func_as
           (Sconst
             (dollar_quoted_string) @injection.content))))))
- (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
+ (?i)^plpgsql$
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -254,7 +254,7 @@
         (NonReservedWord_or_Sconst
           (NonReservedWord
             (identifier) @_lang))))))
- (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
+ (?i)^plpgsql$
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 

--- a/postgres/queries/injections.scm
+++ b/postgres/queries/injections.scm
@@ -26,7 +26,7 @@
         (func_as
           (Sconst
             (dollar_quoted_string) @injection.content))))))
- (#eq? @_lang "plpgsql")
+ (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -44,7 +44,7 @@
         (NonReservedWord_or_Sconst
           (NonReservedWord
             (identifier) @_lang))))))
- (#eq? @_lang "plpgsql")
+ (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -63,7 +63,7 @@
         (func_as
           (Sconst
             (dollar_quoted_string) @injection.content))))))
- (#eq? @_lang "plpgsql")
+ (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -82,7 +82,7 @@
         (NonReservedWord_or_Sconst
           (NonReservedWord
             (identifier) @_lang))))))
- (#eq? @_lang "plpgsql")
+ (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -102,7 +102,7 @@
         (func_as
           (Sconst
             (dollar_quoted_string) @injection.content))))))
- (#eq? @_lang "plpgsql")
+ (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -122,7 +122,7 @@
         (NonReservedWord_or_Sconst
           (NonReservedWord
             (identifier) @_lang))))))
- (#eq? @_lang "plpgsql")
+ (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -143,7 +143,7 @@
         (func_as
           (Sconst
             (dollar_quoted_string) @injection.content))))))
- (#eq? @_lang "plpgsql")
+ (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -164,7 +164,7 @@
         (NonReservedWord_or_Sconst
           (NonReservedWord
             (identifier) @_lang))))))
- (#eq? @_lang "plpgsql")
+ (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -186,7 +186,7 @@
         (func_as
           (Sconst
             (dollar_quoted_string) @injection.content))))))
- (#eq? @_lang "plpgsql")
+ (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -208,7 +208,7 @@
         (NonReservedWord_or_Sconst
           (NonReservedWord
             (identifier) @_lang))))))
- (#eq? @_lang "plpgsql")
+ (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -231,7 +231,7 @@
         (func_as
           (Sconst
             (dollar_quoted_string) @injection.content))))))
- (#eq? @_lang "plpgsql")
+ (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 
@@ -254,7 +254,7 @@
         (NonReservedWord_or_Sconst
           (NonReservedWord
             (identifier) @_lang))))))
- (#eq? @_lang "plpgsql")
+ (#match? @_lang "^[pP][lL][pP][gG][sS][qQ][lL]$")
  (#set! injection.language "plpgsql")
  (#set! injection.include-children))
 


### PR DESCRIPTION
related to #14 
closes #14 

@gmr Hello! Can you please take a look.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced PL/pgSQL code detection to work regardless of capitalization, ensuring consistent syntax highlighting and code injection handling across all case variations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gmr/tree-sitter-postgres/pull/15)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->