### PR TITLE
fix: dollar-quote over-capture and plpgsql NULL truncation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
             path: ".",
             sources: [
                 "postgres/src/parser.c",
+                "postgres/src/scanner.c",
                 "plpgsql/src/parser.c",
                 "plpgsql/src/scanner.c",
             ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,6 +12,7 @@
       "sources": [
         "bindings/node/binding.cc",
         "postgres/src/parser.c",
+        "postgres/src/scanner.c",
         "plpgsql/src/parser.c",
         "plpgsql/src/scanner.c",
       ],

--- a/bindings/go/binding.go
+++ b/bindings/go/binding.go
@@ -2,6 +2,7 @@ package tree_sitter_postgres
 
 // #cgo CFLAGS: -std=c11 -fPIC
 // #include "../../postgres/src/parser.c"
+// #include "../../postgres/src/scanner.c"
 // #include "../../plpgsql/src/parser.c"
 // #include "../../plpgsql/src/scanner.c"
 import "C"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -8,10 +8,14 @@ fn main() {
     #[cfg(target_env = "msvc")]
     c_config.flag("-utf-8");
 
-    // postgres parser
+    // postgres parser + external scanner (dollar-quoted strings)
     let parser_path = pg_src.join("parser.c");
     c_config.file(&parser_path);
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+
+    let pg_scanner = pg_src.join("scanner.c");
+    c_config.file(&pg_scanner);
+    println!("cargo:rerun-if-changed={}", pg_scanner.to_str().unwrap());
 
     // plpgsql parser + external scanner
     let plpgsql_parser = plpgsql_src.join("parser.c");

--- a/plpgsql/src/parser.c
+++ b/plpgsql/src/parser.c
@@ -28666,9 +28666,9 @@ TS_PUBLIC const TSLanguage *tree_sitter_plpgsql(void) {
     .name = "plpgsql",
     .max_reserved_word_set_size = 0,
     .metadata = {
-      .major_version = 0,
+      .major_version = 1,
       .minor_version = 1,
-      .patch_version = 0,
+      .patch_version = 4,
     },
   };
   return &language;

--- a/plpgsql/src/scanner.c
+++ b/plpgsql/src/scanner.c
@@ -102,9 +102,13 @@ bool tree_sitter_plpgsql_external_scanner_scan(
         }
         return false;
       }
-      /* Single < — part of SQL operator, continue */
-
+      /* Single < — part of a SQL comparison operator. The catch-all branch
+       * at the bottom of the loop would set expecting_value=true for '<',
+       * but this earlier branch consumes the char and `continue`s, so it
+       * must update the flag itself or `IF x < NULL THEN` would truncate
+       * at NULL (the next token wouldn't be recognized as a value). */
       has_content = true;
+      expecting_value = true;
       continue;
     }
 

--- a/plpgsql/src/scanner.c
+++ b/plpgsql/src/scanner.c
@@ -74,6 +74,18 @@ bool tree_sitter_plpgsql_external_scanner_scan(
   int depth = 0;
   bool has_content = false;
 
+  /*
+   * Track whether the next token at depth 0 is expected to be a value.
+   * `null` is a PL/pgSQL delimiter only as a fresh statement (`NULL;`), but
+   * inside an expression — after IS, IS NOT, =, <>, !=, IN, AND, OR, LIKE,
+   * BETWEEN, NOT, AS, or a binary operator — `NULL` is the SQL literal and
+   * must be consumed as part of `sql_expression`. We default to `false` so
+   * a bare leading `NULL` still falls through to the kw_null token (which
+   * `stmt_null` consumes); the flag flips to `true` only after the scanner
+   * has seen something that requires a value next.
+   */
+  bool expecting_value = false;
+
   while (lexer->lookahead != 0) {
     /* At depth 0, semicolon terminates */
     if (depth == 0 && lexer->lookahead == ';') break;
@@ -141,6 +153,7 @@ bool tree_sitter_plpgsql_external_scanner_scan(
       depth++;
       lexer->advance(lexer, false);
       has_content = true;
+      expecting_value = true;
       continue;
     }
     if (lexer->lookahead == ')' || lexer->lookahead == ']') {
@@ -148,6 +161,7 @@ bool tree_sitter_plpgsql_external_scanner_scan(
         depth--;
         lexer->advance(lexer, false);
         has_content = true;
+        expecting_value = false;
         continue;
       }
       /* Unbalanced close — stop */
@@ -167,6 +181,7 @@ bool tree_sitter_plpgsql_external_scanner_scan(
         }
       }
       has_content = true;
+      expecting_value = false;
       continue;
     }
 
@@ -175,6 +190,7 @@ bool tree_sitter_plpgsql_external_scanner_scan(
       /* Just consume the $ and let it be part of the expression */
       lexer->advance(lexer, false);
       has_content = true;
+      expecting_value = false;
       continue;
     }
 
@@ -234,6 +250,19 @@ bool tree_sitter_plpgsql_external_scanner_scan(
         lexer->advance(lexer, false);
       }
       word[len] = '\0';
+
+      /* `null` is a PL/pgSQL delimiter only as a bare NULL statement.
+       * Inside an expression — after IS, IS NOT, =, <>, !=, IN, AND, OR,
+       * NOT, LIKE, etc., or any binary operator — NULL is the SQL literal
+       * and must be consumed as part of the expression. We approximate
+       * "inside an expression" with the `expecting_value` flag, which is
+       * set by operators, opening parens, comma, and value-expecting
+       * keywords like IS/NOT/AND/OR/IN/LIKE/BETWEEN. */
+      if (strcmp(word, "null") == 0 && expecting_value) {
+        has_content = true;
+        expecting_value = false;
+        continue;
+      }
 
       /* Check if this word is a PL/pgSQL structural delimiter.
        * These are keywords that, in context, indicate the end of a SQL
@@ -297,6 +326,17 @@ bool tree_sitter_plpgsql_external_scanner_scan(
         return false;
       }
 
+      /* Non-delimiter word: update expecting_value based on whether the
+       * word naturally precedes a value (binary operators, IS, NOT, etc.) */
+      if (strcmp(word, "is") == 0 || strcmp(word, "not") == 0 ||
+          strcmp(word, "and") == 0 || strcmp(word, "or") == 0 ||
+          strcmp(word, "in") == 0 || strcmp(word, "like") == 0 ||
+          strcmp(word, "ilike") == 0 || strcmp(word, "between") == 0 ||
+          strcmp(word, "similar") == 0 || strcmp(word, "as") == 0) {
+        expecting_value = true;
+      } else {
+        expecting_value = false;
+      }
 
       has_content = true;
       continue;
@@ -310,6 +350,7 @@ bool tree_sitter_plpgsql_external_scanner_scan(
       }
 
       has_content = true;
+      expecting_value = false;
       continue;
     }
     /* Inside parens, consume identifiers without keyword checking */
@@ -324,8 +365,20 @@ bool tree_sitter_plpgsql_external_scanner_scan(
     }
 
     /* Everything else (operators, digits, etc.) — just consume */
+    int c = lexer->lookahead;
     lexer->advance(lexer, false);
     has_content = true;
+    if (depth == 0) {
+      if (c == '+' || c == '-' || c == '*' || c == '/' || c == '%' ||
+          c == '<' || c == '>' || c == '=' || c == '~' || c == '!' ||
+          c == '@' || c == '#' || c == '^' || c == '&' || c == '|' ||
+          c == '?' || c == ',') {
+        expecting_value = true;
+      } else if (c >= '0' && c <= '9') {
+        expecting_value = false;
+      }
+      /* '.' and other punctuation: leave expecting_value unchanged */
+    }
   }
 
   if (has_content) {

--- a/plpgsql/test/corpus/control_flow.txt
+++ b/plpgsql/test/corpus/control_flow.txt
@@ -343,3 +343,32 @@ END
           (kw_end)
           (kw_if))))
     (kw_end)))
+
+==================
+If with single less-than against NULL
+==================
+
+BEGIN
+  IF x < NULL THEN
+    NULL;
+  END IF;
+END
+
+---
+
+(source_file
+  (pl_block
+    (kw_begin)
+    (proc_sect
+      (proc_stmt
+        (stmt_if
+          (kw_if)
+          (sql_expression)
+          (kw_then)
+          (proc_sect
+            (proc_stmt
+              (stmt_null
+                (kw_null))))
+          (kw_end)
+          (kw_if))))
+    (kw_end)))

--- a/plpgsql/test/corpus/control_flow.txt
+++ b/plpgsql/test/corpus/control_flow.txt
@@ -256,3 +256,90 @@ END
             (any_identifier
               (identifier))))))
     (kw_end)))
+
+==================
+If with IS NULL
+==================
+
+BEGIN
+  IF x IS NULL THEN
+    NULL;
+  END IF;
+END
+
+---
+
+(source_file
+  (pl_block
+    (kw_begin)
+    (proc_sect
+      (proc_stmt
+        (stmt_if
+          (kw_if)
+          (sql_expression)
+          (kw_then)
+          (proc_sect
+            (proc_stmt
+              (stmt_null
+                (kw_null))))
+          (kw_end)
+          (kw_if))))
+    (kw_end)))
+
+==================
+If with IS NOT NULL
+==================
+
+BEGIN
+  IF x IS NOT NULL THEN
+    NULL;
+  END IF;
+END
+
+---
+
+(source_file
+  (pl_block
+    (kw_begin)
+    (proc_sect
+      (proc_stmt
+        (stmt_if
+          (kw_if)
+          (sql_expression)
+          (kw_then)
+          (proc_sect
+            (proc_stmt
+              (stmt_null
+                (kw_null))))
+          (kw_end)
+          (kw_if))))
+    (kw_end)))
+
+==================
+If with NULL comparisons
+==================
+
+BEGIN
+  IF x = NULL OR y <> NULL THEN
+    NULL;
+  END IF;
+END
+
+---
+
+(source_file
+  (pl_block
+    (kw_begin)
+    (proc_sect
+      (proc_stmt
+        (stmt_if
+          (kw_if)
+          (sql_expression)
+          (kw_then)
+          (proc_sect
+            (proc_stmt
+              (stmt_null
+                (kw_null))))
+          (kw_end)
+          (kw_if))))
+    (kw_end)))

--- a/postgres/grammar.js
+++ b/postgres/grammar.js
@@ -21,6 +21,13 @@ module.exports = grammar({
   // Keywords (prec 1) outrank identifiers (prec 0) on the same text.
   word: $ => $.identifier,
 
+  // External tokens — implemented in postgres/src/scanner.c.
+  // dollar_quoted_string must match opening and closing tags exactly,
+  // which a tree-sitter regex token cannot enforce.
+  externals: $ => [
+    $.dollar_quoted_string,
+  ],
+
   // Conflicts: PostgreSQL's grammar has many shift/reduce conflicts that
   // Bison resolves via precedence rules. Tree-sitter (GLR) will handle
   // these as ambiguities. Conflict pairs are stored in script/known-conflicts.json
@@ -4734,9 +4741,11 @@ module.exports = grammar({
     // treats E'...' the same as a function call to E() at parse time.
 
     // Dollar-quoted string: $$body$$ or $tag$body$tag$
-    // NOTE: full correctness requires matching the open/close tags;
-    // this regex accepts any dollar-quoted form and is good enough for highlighting.
-    dollar_quoted_string: _ => token(/\$[a-zA-Z_0-9]*\$[\s\S]*?\$[a-zA-Z_0-9]*\$/),
+    // Handled by the external scanner (postgres/src/scanner.c) so the
+    // open/close tags must match exactly. A pure regex cannot enforce that
+    // because tree-sitter compiles tokens into a DFA that ignores non-greedy
+    // `*?`, which previously caused over-capture across multiple quoted
+    // strings in a single file.
 
     // Bit string: B'0101'
     bit_string_literal: _ => token(/[bB]'[01]*'/),

--- a/postgres/src/grammar.json
+++ b/postgres/src/grammar.json
@@ -60309,13 +60309,6 @@
         "value": "'([^']|'')*'"
       }
     },
-    "dollar_quoted_string": {
-      "type": "TOKEN",
-      "content": {
-        "type": "PATTERN",
-        "value": "\\$[a-zA-Z_0-9]*\\$[\\s\\S]*?\\$[a-zA-Z_0-9]*\\$"
-      }
-    },
     "bit_string_literal": {
       "type": "TOKEN",
       "content": {
@@ -60403,7 +60396,12 @@
     ]
   ],
   "precedences": [],
-  "externals": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "dollar_quoted_string"
+    }
+  ],
   "inline": [],
   "supertypes": [],
   "reserved": {}

--- a/postgres/src/parser.c
+++ b/postgres/src/parser.c
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77ec3b62dc9cbb9ae8dac66e1c234d59b80c5a865878fcdecbaeb49eb5d1d387
-size 92447278
+oid sha256:3945e629225f18d70f310e2f21d0d4fec958081857bc7703b877fbf2e3524c82
+size 94807037

--- a/postgres/src/scanner.c
+++ b/postgres/src/scanner.c
@@ -29,10 +29,19 @@ void tree_sitter_postgres_external_scanner_deserialize(void *payload, const char
 /*
  * Self-contained ASCII helpers so the compiled Wasm does not import libc
  * functions like isalnum/tolower that Zed's grammar runtime cannot resolve.
+ *
+ * Dollar-quote tags follow PostgreSQL identifier rules: the first character
+ * must be a letter (ASCII or non-ASCII via UTF-8 lead bytes >= 0x80) or an
+ * underscore; subsequent characters may also be digits. Tags must not contain
+ * a dollar sign. See sql-syntax-lexical.html in the PostgreSQL docs.
  */
-static bool is_tag_char(int c) {
+static bool is_tag_start_char(int c) {
   return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
-         (c >= '0' && c <= '9') || c == '_';
+         c == '_' || c >= 0x80;
+}
+
+static bool is_tag_char(int c) {
+  return is_tag_start_char(c) || (c >= '0' && c <= '9');
 }
 
 static void skip_whitespace(TSLexer *lexer) {
@@ -54,13 +63,17 @@ bool tree_sitter_postgres_external_scanner_scan(
 
   lexer->advance(lexer, false);
 
-  /* PostgreSQL caps identifier length at NAMEDATALEN-1 = 63. */
+  /* PostgreSQL caps identifier length at NAMEDATALEN-1 = 63.
+   * Empty tag ($$...$$) is valid; a non-empty tag must start with a letter
+   * or underscore (not a digit). */
   char tag[64];
   int tag_len = 0;
-  while (is_tag_char(lexer->lookahead)) {
-    if (tag_len >= 63) return false;
-    tag[tag_len++] = (char)lexer->lookahead;
-    lexer->advance(lexer, false);
+  if (is_tag_start_char(lexer->lookahead)) {
+    do {
+      if (tag_len >= 63) return false;
+      tag[tag_len++] = (char)lexer->lookahead;
+      lexer->advance(lexer, false);
+    } while (is_tag_char(lexer->lookahead));
   }
 
   if (lexer->lookahead != '$') return false;

--- a/postgres/src/scanner.c
+++ b/postgres/src/scanner.c
@@ -1,0 +1,89 @@
+/**
+ * External scanner for the postgres tree-sitter grammar.
+ *
+ * Provides the dollar_quoted_string token type. PostgreSQL dollar-quoted
+ * strings have the form $tag$...$tag$ where the opening and closing tags
+ * must match exactly. The previous implementation used a non-greedy regex,
+ * but tree-sitter compiles tokens into a DFA that ignores `*?`, so the
+ * effective match was greedy and consumed across multiple dollar-quoted
+ * strings in a single file. This scanner mirrors PostgreSQL's own lexer:
+ * remember the opening tag, then scan forward until a matching $tag$.
+ */
+#include "tree_sitter/parser.h"
+
+#include <string.h>
+
+enum TokenType {
+  DOLLAR_QUOTED_STRING,
+};
+
+void *tree_sitter_postgres_external_scanner_create(void) { return NULL; }
+void tree_sitter_postgres_external_scanner_destroy(void *payload) { (void)payload; }
+unsigned tree_sitter_postgres_external_scanner_serialize(void *payload, char *buffer) {
+  (void)payload; (void)buffer; return 0;
+}
+void tree_sitter_postgres_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
+  (void)payload; (void)buffer; (void)length;
+}
+
+/*
+ * Self-contained ASCII helpers so the compiled Wasm does not import libc
+ * functions like isalnum/tolower that Zed's grammar runtime cannot resolve.
+ */
+static bool is_tag_char(int c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+         (c >= '0' && c <= '9') || c == '_';
+}
+
+static void skip_whitespace(TSLexer *lexer) {
+  while (lexer->lookahead == ' ' || lexer->lookahead == '\t' ||
+         lexer->lookahead == '\n' || lexer->lookahead == '\r') {
+    lexer->advance(lexer, true);
+  }
+}
+
+bool tree_sitter_postgres_external_scanner_scan(
+  void *payload, TSLexer *lexer, const bool *valid_symbols
+) {
+  (void)payload;
+  if (!valid_symbols[DOLLAR_QUOTED_STRING]) return false;
+
+  skip_whitespace(lexer);
+
+  if (lexer->lookahead != '$') return false;
+
+  lexer->advance(lexer, false);
+
+  /* PostgreSQL caps identifier length at NAMEDATALEN-1 = 63. */
+  char tag[64];
+  int tag_len = 0;
+  while (is_tag_char(lexer->lookahead)) {
+    if (tag_len >= 63) return false;
+    tag[tag_len++] = (char)lexer->lookahead;
+    lexer->advance(lexer, false);
+  }
+
+  if (lexer->lookahead != '$') return false;
+  lexer->advance(lexer, false);
+
+  while (lexer->lookahead != 0) {
+    if (lexer->lookahead == '$') {
+      lexer->advance(lexer, false);
+      int i = 0;
+      while (i < tag_len && lexer->lookahead == (unsigned char)tag[i]) {
+        lexer->advance(lexer, false);
+        i++;
+      }
+      if (i == tag_len && lexer->lookahead == '$') {
+        lexer->advance(lexer, false);
+        lexer->result_symbol = DOLLAR_QUOTED_STRING;
+        return true;
+      }
+      /* Partial match — continue scanning body. */
+      continue;
+    }
+    lexer->advance(lexer, false);
+  }
+
+  return false;
+}

--- a/postgres/test/corpus/expressions.txt
+++ b/postgres/test/corpus/expressions.txt
@@ -187,3 +187,86 @@ SELECT 'hello';
                         (AexprConst
                           (Sconst
                             (string_literal)))))))))))))))
+
+================================================================================
+Dollar-quoted string
+================================================================================
+
+SELECT $$hello$$;
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (toplevel_stmt
+    (stmt
+      (SelectStmt
+        (select_no_parens
+          (simple_select
+            (kw_select)
+            (opt_target_list
+              (target_list
+                (target_el
+                  (a_expr
+                    (a_expr
+                      (c_expr
+                        (AexprConst
+                          (Sconst
+                            (dollar_quoted_string)))))))))))))))
+
+================================================================================
+Tagged dollar-quoted string
+================================================================================
+
+SELECT $tag$body with $$ nested$tag$;
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (toplevel_stmt
+    (stmt
+      (SelectStmt
+        (select_no_parens
+          (simple_select
+            (kw_select)
+            (opt_target_list
+              (target_list
+                (target_el
+                  (a_expr
+                    (a_expr
+                      (c_expr
+                        (AexprConst
+                          (Sconst
+                            (dollar_quoted_string)))))))))))))))
+
+================================================================================
+Multiple dollar-quoted strings on one line
+================================================================================
+
+SELECT $a$first$a$, $b$second$b$;
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (toplevel_stmt
+    (stmt
+      (SelectStmt
+        (select_no_parens
+          (simple_select
+            (kw_select)
+            (opt_target_list
+              (target_list
+                (target_list
+                  (target_el
+                    (a_expr
+                      (a_expr
+                        (c_expr
+                          (AexprConst
+                            (Sconst
+                              (dollar_quoted_string))))))))
+                (target_el
+                  (a_expr
+                    (a_expr
+                      (c_expr
+                        (AexprConst
+                          (Sconst
+                            (dollar_quoted_string)))))))))))))))

--- a/script/codegen.js
+++ b/script/codegen.js
@@ -496,9 +496,11 @@ function generateLexerRules() {
     // treats E'...' the same as a function call to E() at parse time.
 
     // Dollar-quoted string: $$body$$ or $tag$body$tag$
-    // NOTE: full correctness requires matching the open/close tags;
-    // this regex accepts any dollar-quoted form and is good enough for highlighting.
-    dollar_quoted_string: _ => token(/\\$[a-zA-Z_0-9]*\\$[\\s\\S]*?\\$[a-zA-Z_0-9]*\\$/),
+    // Handled by the external scanner (postgres/src/scanner.c) so the
+    // open/close tags must match exactly. A pure regex cannot enforce that
+    // because tree-sitter compiles tokens into a DFA that ignores non-greedy
+    // \`*?\`, which previously caused over-capture across multiple quoted
+    // strings in a single file.
 
     // Bit string: B'0101'
     bit_string_literal: _ => token(/[bB]'[01]*'/),
@@ -616,6 +618,13 @@ module.exports = grammar({
   // 'word' lets tree-sitter know which rule represents bare identifiers.
   // Keywords (prec 1) outrank identifiers (prec 0) on the same text.
   word: $ => $.identifier,
+
+  // External tokens — implemented in postgres/src/scanner.c.
+  // dollar_quoted_string must match opening and closing tags exactly,
+  // which a tree-sitter regex token cannot enforce.
+  externals: $ => [
+    $.dollar_quoted_string,
+  ],
 
   // Conflicts: PostgreSQL's grammar has many shift/reduce conflicts that
   // Bison resolves via precedence rules. Tree-sitter (GLR) will handle

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
             sources=[
                 "bindings/python/tree_sitter_postgres/binding.c",
                 "postgres/src/parser.c",
+                "postgres/src/scanner.c",
                 "plpgsql/src/parser.c",
                 "plpgsql/src/scanner.c",
             ],


### PR DESCRIPTION
Addresses the two parser bugs reported in #10 by @AlexS778.

## 1. Dollar-quoted string over-capture (postgres)

`dollar_quoted_string` was a `token(/\$[a-zA-Z_0-9]*\$[\s\S]*?\$[a-zA-Z_0-9]*\$/)`. Tree-sitter compiles `token()` regexes into a lexer DFA that does not honor non-greedy `*?`, so the match was effectively greedy and consumed across multiple `$$...$$` strings in a single file — two `CREATE FUNCTION ... $$ ... $$;` statements collapsed into one `CreateFunctionStmt` whose `dollar_quoted_string` spanned both bodies. The regex also did not enforce matched open/close tags (`$a$body$b$` would have matched).

Fix: add a postgres external scanner (`postgres/src/scanner.c`) that mirrors PostgreSQL's lexer — record the opening tag, scan forward, only succeed on a matching `$tag$`. Codegen emits an `externals` block and drops the lexer-level token rule, so the fix survives `tree-sitter generate` regeneration when PostgreSQL releases a new version. All five binding manifests (binding.gyp, build.rs, binding.go, setup.py, Package.swift) now compile the scanner.

## 2. plpgsql scanner truncates SQL at NULL

The plpgsql `_sql_body` external scanner treated `null` as a structural delimiter at every depth-0 occurrence, so `IF _kind IS NULL OR length(_kind) = 0 THEN` parsed as `sql_expression = "_kind IS "` with an ERROR node covering `NULL OR length(_kind) = 0`.

Fix: track an `expecting_value` flag in the scanner. Operators (`+ - * / % < > = ~ ! @ # ^ & | ? ,`), opening parens, and value-expecting keywords (`IS`, `NOT`, `AND`, `OR`, `IN`, `LIKE`, `ILIKE`, `BETWEEN`, `SIMILAR`, `AS`) set it true. The flag defaults to false so a bare leading `NULL` still falls through to `kw_null` and `stmt_null` matches — preserving every existing corpus test.

`INTO` is intentionally left untouched. As @AlexS778 noted, `SELECT col INTO var FROM t` requires knowing whether a select-list has already been consumed, which is messier than the NULL case and deserves its own pass.

## Test plan

- [x] `tree-sitter test` — postgres corpus: 38/38 (3 new dollar-quote tests)
- [x] `tree-sitter test` — plpgsql corpus: 56/56 (3 new IS NULL / IS NOT NULL / NULL comparison tests)
- [x] `cargo test` — Rust bindings load both grammars
- [x] Original bug reproductions parse correctly: two `$$...$$` functions in one file produce two `CreateFunctionStmt`s; `IF x IS NULL THEN ... END IF` parses with full `sql_expression`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External scanner for PostgreSQL dollar-quoted strings now correctly handles tag matching without regex limitations.

* **Bug Fixes**
  * Improved PL/pgSQL null keyword handling with better value-expectation tracking to prevent misinterpretation in SQL expressions.

* **Tests**
  * Added test cases for dollar-quoted string expressions.
  * Added test cases for NULL comparison handling in control flow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gmr/tree-sitter-postgres/pull/18)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->