### PR TITLE
fix: Fix PL/pgSQL scanner handling for boundary comments

### DIFF
--- a/plpgsql/src/scanner.c
+++ b/plpgsql/src/scanner.c
@@ -202,6 +202,7 @@ bool tree_sitter_plpgsql_external_scanner_scan(
     if (lexer->lookahead == '-') {
       lexer->advance(lexer, false);
       if (lexer->lookahead == '-') {
+        if (!has_content) return false;
         /* Line comment — consume to end of line */
         while (lexer->lookahead != 0 && lexer->lookahead != '\n') {
           lexer->advance(lexer, false);
@@ -215,6 +216,7 @@ bool tree_sitter_plpgsql_external_scanner_scan(
     if (lexer->lookahead == '/') {
       lexer->advance(lexer, false);
       if (lexer->lookahead == '*') {
+        if (!has_content) return false;
         /* Block comment */
         lexer->advance(lexer, false);
         int comment_depth = 1;

--- a/plpgsql/test/corpus/statements.txt
+++ b/plpgsql/test/corpus/statements.txt
@@ -186,3 +186,93 @@ END
         (stmt_rollback
           (kw_rollback))))
     (kw_end)))
+
+==================
+Comments before statements
+==================
+
+BEGIN
+  -- leading line comment
+  IF x THEN
+    NULL;
+  END IF;
+  /* leading block comment */
+  NULL;
+END
+
+---
+
+(source_file
+  (pl_block
+    (kw_begin)
+    (comment)
+    (proc_sect
+      (proc_stmt
+        (stmt_if
+          (kw_if)
+          (sql_expression)
+          (kw_then)
+          (proc_sect
+            (proc_stmt
+              (stmt_null
+                (kw_null))))
+          (kw_end)
+          (kw_if)))
+      (comment)
+      (proc_stmt
+        (stmt_null
+          (kw_null))))
+    (kw_end)))
+
+==================
+Comments after statements
+==================
+
+BEGIN
+  RETURN 1; -- trailing line comment
+  RETURN 2; /* trailing block comment */
+END
+
+---
+
+(source_file
+  (pl_block
+    (kw_begin)
+    (proc_sect
+      (proc_stmt
+        (stmt_return
+          (kw_return)
+          (sql_expression)))
+      (comment)
+      (proc_stmt
+        (stmt_return
+          (kw_return)
+          (sql_expression))))
+    (comment)
+    (kw_end)))
+
+==================
+Comments inside SQL expressions
+==================
+
+BEGIN
+  RETURN 1 /* inside block comment */ + 2;
+  RETURN 1 -- inside line comment
+    + 2;
+END
+
+---
+
+(source_file
+  (pl_block
+    (kw_begin)
+    (proc_sect
+      (proc_stmt
+        (stmt_return
+          (kw_return)
+          (sql_expression)))
+      (proc_stmt
+        (stmt_return
+          (kw_return)
+          (sql_expression))))
+    (kw_end)))


### PR DESCRIPTION
Prevent the PL/pgSQL external scanner from treating leading line/block comments as sql_expression content when no SQL body has started yet. This lets grammar extras consume comments at statement boundaries while preserving comment handling inside already-started SQL expressions.

Add corpus coverage for comments before statements, after statements, and inside SQL expressions.

closes #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PL/pgSQL parser handling of comments appearing before SQL content. The parser now correctly stops SQL body scanning when encountering comments before any actual SQL has been processed, ensuring accurate parse results.

* **Tests**
  * Added test fixtures for comprehensive comment coverage in PL/pgSQL, including comments positioned before statements, after statements, and embedded within SQL expressions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gmr/tree-sitter-postgres/pull/21)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->