### PR TITLE
fix(plpgsql): sync generator with committed grammar

### DIFF
--- a/script/generate-plpgsql-grammar.js
+++ b/script/generate-plpgsql-grammar.js
@@ -196,6 +196,9 @@ module.exports = grammar({
     ),
 
     decl_statement: $ => choice(
+      // Alias declaration: name ALIAS FOR target ;
+      // Must precede variable declaration so ALIAS is not consumed as a type name.
+      seq($.decl_varname, $.kw_alias, $.kw_for, $.any_identifier, ';'),
       // Variable declaration: name [CONSTANT] type [COLLATE collation] [NOT NULL] [DEFAULT|:=|= expr] ;
       seq(
         $.decl_varname,
@@ -206,8 +209,6 @@ module.exports = grammar({
         optional($.decl_defval),
         ';'
       ),
-      // Alias declaration: name ALIAS FOR target ;
-      seq($.decl_varname, $.kw_alias, $.kw_for, $.any_identifier, ';'),
       // Cursor declaration: name [NO SCROLL | SCROLL] CURSOR [(args)] FOR|IS query ;
       seq(
         $.decl_varname,
@@ -560,7 +561,8 @@ module.exports = grammar({
     stmt_fetch: $ => seq(
       $.kw_fetch,
       optional($.fetch_direction),
-      optional(seq($.kw_from, $.any_identifier)),
+      optional($.kw_from),
+      $.any_identifier,
       $.kw_into,
       $.into_target,
       ';'

--- a/script/generate-plpgsql-grammar.test.js
+++ b/script/generate-plpgsql-grammar.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const projectRoot = path.join(__dirname, '..');
+
+function readRepoFile(relativePath) {
+  return fs.readFileSync(path.join(projectRoot, relativePath), 'utf8');
+}
+
+function extractTopLevelRule(source, ruleName) {
+  const pattern = new RegExp(
+    String.raw`^    ${ruleName}: \$ => [\s\S]*?^    \),`,
+    'm'
+  );
+  const match = source.match(pattern);
+  assert.ok(match, `Could not find top-level rule ${ruleName}`);
+  return match[0].trimEnd();
+}
+
+test('PL/pgSQL generator template matches committed grammar for drift-sensitive rules', () => {
+  const generator = readRepoFile('script/generate-plpgsql-grammar.js');
+  const grammar = readRepoFile('plpgsql/grammar.js');
+
+  for (const ruleName of ['decl_statement', 'stmt_fetch']) {
+    assert.equal(
+      extractTopLevelRule(generator, ruleName),
+      extractTopLevelRule(grammar, ruleName),
+      `${ruleName} differs between script/generate-plpgsql-grammar.js and plpgsql/grammar.js`
+    );
+  }
+});


### PR DESCRIPTION
Update the PL/pgSQL grammar generator so it matches the committed plpgsql/grammar.js for drift-sensitive rules.

- emit alias declarations before variable declarations
- emit FETCH as optional FROM plus required cursor name
- add a lightweight generator drift test for decl_statement and stmt_fetch

This prevents future regeneration from undoing the current committed grammar shape.

## Summary

This PR fixes drift between the committed `plpgsql/grammar.js` and its generator template in `script/generate-plpgsql-grammar.js`.

The committed grammar already has the intended behavior. This PR moves that behavior back into the generator so future regeneration does not undo it.

## Changes

### Declaration ordering

Updated `decl_statement` generation so alias declarations are emitted before variable declarations.

This preserves the existing intended behavior where:

```plpgsql
x ALIAS FOR old_name;
```
is parsed as an alias declaration rather than being confused with a variable declaration whose type name starts with ALIAS.

FETCH statement shape
Updated generated stmt_fetch from:

```js

optional(seq($.kw_from, $.any_identifier)),
$.kw_into,

```
to:

```js

optional($.kw_from),
$.any_identifier,
$.kw_into,
```
This matches the committed grammar and supports both:

```plpgsql

FETCH curs INTO x;
FETCH NEXT FROM curs INTO x;
```

## Testing

Ran lightweight generator drift tests:

```sh
node --test script/*.test.js
```


Result:

```
4/4 passed
```
Ran PL/pgSQL corpus tests:

```sh

cd plpgsql
../node_modules/.bin/tree-sitter test
```
Result:

```
60/60 passed
```

Full PostgreSQL parser regeneration was not run because this PR only updates the PL/pgSQL generator template and does not change the committed generated PL/pgSQL grammar.


It does not change the broader PL/pgSQL scanner architecture or the _sql_body handling discussed separately.




Closes #29 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test to detect drift between generated and committed grammar for PL/pgSQL parsing rules.

* **Chores**
  * Updated internal grammar generation script with adjusted rule ordering and token parsing logic for PL/pgSQL dialect support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gmr/tree-sitter-postgres/pull/30?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->