### PR TITLE
Fix AT TIME ZONE parse (GLR conflict with AT LOCAL)

### DIFF
--- a/postgres/grammar.js
+++ b/postgres/grammar.js
@@ -2647,7 +2647,6 @@ module.exports = grammar({
         $.c_expr,
         prec.left(21, prec.dynamic(21, seq($.a_expr_prec, '::', $.Typename))),
         prec.left(17, prec.dynamic(17, seq($.a_expr_prec, $.kw_collate, $.any_name))),
-        prec.left(16, prec.dynamic(16, seq($.a_expr_prec, $.kw_at, $.kw_local))),
         prec.right(18, prec.dynamic(18, seq('+', $.a_expr_prec))),
         prec.right(18, prec.dynamic(18, seq('-', $.a_expr_prec))),
         prec.left(13, prec.dynamic(13, seq($.a_expr_prec, '+', $.a_expr_prec))),
@@ -2663,6 +2662,7 @@ module.exports = grammar({
     a_expr: $ => choice(
         alias($.a_expr_prec, $.a_expr),
         prec.left(16, prec.dynamic(16, seq($.a_expr, $.kw_at, $.kw_time, $.kw_zone, $.a_expr))),
+        prec.left(16, prec.dynamic(16, seq($.a_expr, $.kw_at, $.kw_local))),
         prec.left(7, prec.dynamic(7, seq($.a_expr, '<=', $.a_expr))),
         prec.left(7, prec.dynamic(7, seq($.a_expr, '>=', $.a_expr))),
         prec.left(7, prec.dynamic(7, seq($.a_expr, '<>', $.a_expr))),

--- a/postgres/src/grammar.json
+++ b/postgres/src/grammar.json
@@ -41637,31 +41637,6 @@
           }
         },
         {
-          "type": "PREC_LEFT",
-          "value": 16,
-          "content": {
-            "type": "PREC_DYNAMIC",
-            "value": 16,
-            "content": {
-              "type": "SEQ",
-              "members": [
-                {
-                  "type": "SYMBOL",
-                  "name": "a_expr_prec"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "kw_at"
-                },
-                {
-                  "type": "SYMBOL",
-                  "name": "kw_local"
-                }
-              ]
-            }
-          }
-        },
-        {
           "type": "PREC_RIGHT",
           "value": 18,
           "content": {
@@ -41970,6 +41945,31 @@
                 {
                   "type": "SYMBOL",
                   "name": "a_expr"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "type": "PREC_LEFT",
+          "value": 16,
+          "content": {
+            "type": "PREC_DYNAMIC",
+            "value": 16,
+            "content": {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "a_expr"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "kw_at"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "kw_local"
                 }
               ]
             }

--- a/postgres/src/node-types.json
+++ b/postgres/src/node-types.json
@@ -9442,15 +9442,7 @@
           "named": true
         },
         {
-          "type": "kw_at",
-          "named": true
-        },
-        {
           "type": "kw_collate",
-          "named": true
-        },
-        {
-          "type": "kw_local",
           "named": true
         }
       ]

--- a/postgres/src/parser.c
+++ b/postgres/src/parser.c
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:046a65fee128196ddc9f43f8baaacc0dfd5f9ccea6a13bb074c87c82bcdd2714
-size 97199050
+oid sha256:f3476008bd5bdd6ee4ca870d05e61cc0b7578636209c3912b717c33f9eb19d08
+size 97196966

--- a/postgres/test/corpus/expressions.txt
+++ b/postgres/test/corpus/expressions.txt
@@ -301,3 +301,57 @@ SELECT 0.00, 0.0;
                       (c_expr
                         (AexprConst
                           (float_literal))))))))))))))
+
+================================================================================
+AT TIME ZONE and AT LOCAL
+================================================================================
+
+SELECT ts AT TIME ZONE 'UTC', ts AT LOCAL FROM t;
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (toplevel_stmt
+    (stmt
+      (SelectStmt
+        (select_no_parens
+          (simple_select
+            (kw_select)
+            (opt_target_list
+              (target_list
+                (target_list
+                  (target_el
+                    (a_expr
+                      (a_expr
+                        (a_expr
+                          (c_expr
+                            (columnref
+                              (ColId
+                                (identifier))))))
+                      (kw_at)
+                      (kw_time)
+                      (kw_zone)
+                      (a_expr
+                        (a_expr
+                          (c_expr
+                            (AexprConst
+                              (Sconst
+                                (string_literal)))))))))
+                (target_el
+                  (a_expr
+                    (a_expr
+                      (a_expr
+                        (c_expr
+                          (columnref
+                            (ColId
+                              (identifier))))))
+                    (kw_at)
+                    (kw_local)))))
+            (from_clause
+              (kw_from)
+              (from_list
+                (table_ref
+                  (relation_expr
+                    (qualified_name
+                      (ColId
+                        (identifier)))))))))))))

--- a/script/codegen.js
+++ b/script/codegen.js
@@ -391,8 +391,13 @@ function generateExprRule(name, rule, terminals, kwTokenMap, optionalRules, prec
       // These have unique operator tokens that don't create multi-way conflicts.
       // The operator must have declared precedence and not be a complex keyword
       // that starts multiple alternatives (like IS, IN, LIKE, AND, OR, etc.)
+      // AT is excluded so `a_expr AT LOCAL` stays in the main rule alongside
+      // `a_expr AT TIME ZONE a_expr` (5 tokens, never a clean op). Otherwise AT
+      // LOCAL goes into the self-referential _prec rule and AT TIME ZONE does
+      // not, creating a shift/reduce conflict on `expr AT ...` that the parser
+      // resolves toward AT LOCAL — so `x AT TIME ZONE y` fails to parse.
       const complexKw = new Set(['IS', 'ISNULL', 'NOTNULL', 'IN_P', 'LIKE', 'ILIKE',
-        'SIMILAR', 'BETWEEN', 'NOT', 'NOT_LA', 'AND', 'OR']);
+        'SIMILAR', 'BETWEEN', 'NOT', 'NOT_LA', 'AND', 'OR', 'AT']);
       if (syntaxTokens.length === 3
           && syntaxTokens[0].type === 'SYMBOL' && syntaxTokens[0].value === name
           && syntaxTokens[1].type === 'SYMBOL' && !complexKw.has(syntaxTokens[1].value)


### PR DESCRIPTION
## Summary

`expr AT TIME ZONE zone` failed to parse — `TIME` was lexed as a bare identifier and the expression became an `ERROR` node. This affected real catalog-dumped views (`(col AT TIME ZONE 'UTC'::text)`).

### Root cause
`a_expr AT LOCAL` (3 tokens) matched the codegen's "clean binary-postfix op" heuristic and was emitted into the self-referential `a_expr_prec` rule, while `a_expr AT TIME ZONE a_expr` (5 tokens) stayed in the main `a_expr` rule. After parsing `expr AT`, the parser faced a shift/reduce conflict and resolved it toward the `a_expr_prec` `AT LOCAL` path — so `kw_time` was never an expected token and `TIME` fell back to `identifier`.

### Fix
Add `AT` to codegen's `complexKw` exclusion set so `AT LOCAL` stays in the main `a_expr` rule alongside `AT TIME ZONE`. Both are then reachable from the same state and resolved by lookahead on the token after `AT` (`LOCAL` vs `TIME`).

## Verification
- Regenerated `grammar.js` from `gram.y` and rebuilt `parser.c` (full parse-table build, exit 0 — no new conflicts).
- `tree-sitter test` — all 52 corpus tests pass (added an `AT TIME ZONE and AT LOCAL` case).
- The 3 previously-failing production views now parse with **zero ERROR nodes**; downstream libpgfmt full suite green.
- Tree shape verified: `(a_expr … (kw_at) (kw_time) (kw_zone) a_expr)`.

Retires a long-standing known limitation and is a prerequisite for byte-idempotent `pg_dump`-style formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)